### PR TITLE
Use Kirby's panel URL in widget

### DIFF
--- a/widgets/autogit/template.php
+++ b/widgets/autogit/template.php
@@ -67,6 +67,7 @@
 </div>
 
 <script>
+  var panelURL = '<?= panel()->urls->index; ?>'
   var $widget = $('#autogit-widget')
   var $loadingIcon = $('<i class="icon icon-left fa fa-spinner" />')
   var $successIcon = $('<i class="icon icon-left fa fa-check" />')
@@ -83,7 +84,7 @@
     $button.find('.icon').replaceWith($loadingIcon)
     $otherButton.prop('disabled', true)
 
-    $.post('/panel/autogit/' + $button.data('action'))
+    $.post(panelURL + '/autogit/' + $button.data('action'))
       .done(function (res) {
         $button.find('.icon').replaceWith($successIcon)
         $status.text(res.message).show(600)

--- a/widgets/autogit/template.php
+++ b/widgets/autogit/template.php
@@ -67,7 +67,7 @@
 </div>
 
 <script>
-  var panelURL = '<?= panel()->urls->index; ?>'
+  var panelURL = '<?php echo panel()->urls->index ?>'
   var $widget = $('#autogit-widget')
   var $loadingIcon = $('<i class="icon icon-left fa fa-spinner" />')
   var $successIcon = $('<i class="icon icon-left fa fa-check" />')


### PR DESCRIPTION
Hey @pedroborges,

thank you for creating this plugin!

I noticed that the panel widget wouldn't work properly if I installed kirby in a subdirectory (instead of the document root).

Currently, the URL for the `$.post` call is hardcoded to `/panel/autogit`. This patch uses the panel URL that is provided by Kirby (`panel()->urls->index`) and makes the widget work, even if Kirby is installed in a subdirectory. 