### PR TITLE
Use commit authors as committers, too

### DIFF
--- a/lib/autogit.php
+++ b/lib/autogit.php
@@ -45,11 +45,16 @@ class Autogit extends Git
 
     public function commit($message)
     {
-        $this->execute(sprintf(
-            'commit --author %s --message %s',
-            escapeshellarg($this->author()),
-            escapeshellarg($message)
-        ));
+        $author = $this->author();
+
+        $command = sprintf(
+                '-c %s -c %s commit --author %s --message %s',
+                escapeshellarg("user.name={$author['name']}"),
+                escapeshellarg("user.email={$author['email']}"),
+                escapeshellarg("{$author['name']} <{$author['email']}>"),
+                escapeshellarg($message));
+
+        $this->execute($command);
     }
 
     public function pull()
@@ -92,7 +97,7 @@ class Autogit extends Git
             $userEmail = $user->email();
         }
 
-        return "{$userName} <{$userEmail}>";
+        return [ 'name' => $userName, 'email' => $userEmail ];
     }
 
     protected function getMessage($key, $params)


### PR DESCRIPTION
I'm trying to use `kirby-autogit` on a [Webfaction](https://www.webfaction.com/) server. For some strange reason, commits issued by `kirby-autogit` fail with Git's "Tell me who you are!" message, although my global git config contains `user.name` and `user.email` entries and `php` is run with the correct user.

Since I couldn't figure out how to fix this situation and I can imagine that my environment is not the only one suffering from such issues, I figured it's probably easier to make `kirby-autogit` robust against the problem by using the author also as the committer.

The committer name and email are provided using `-c user.name=%s` and `-c user.email=%s` in front of the `commit` command and thus don't rely on any modifications of git config files.